### PR TITLE
Set displayName property for components

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,8 @@ var ActionCableProvider = React.createClass({
   }
 })
 
+ActionCableProvider.displayName = 'ActionCableProvider'
+
 ActionCableProvider.propTypes = {
   cable: React.PropTypes.object,
   url: React.PropTypes.string,
@@ -116,6 +118,8 @@ var ActionCable = React.createClass({
     return null
   }
 })
+
+ActionCable.displayName = 'ActionCable'
 
 ActionCable.propTypes = {
   onReceived: React.PropTypes.func,


### PR DESCRIPTION
Components not defined in JSX need to have their `displayName` property
set explicitly.

Fixes issue where components show up as `<Unknown ... />` in React
DevTools.