### PR TITLE
Re-subscribe when channel changes on instance

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var React = require('react')
 var PropTypes = require('prop-types')
 var actioncable = require('actioncable')
 var createReactClass = require('create-react-class')
+var _isEqual = require('lodash/isEqual')
 
 var ActionCableProvider = createReactClass({
   getChildContext: function () {
@@ -63,16 +64,18 @@ ActionCableProvider.childContextTypes = {
 
 var ActionCable = createReactClass({
   componentDidMount: function () {
-    var self = this;
-    var _props = this.props,
-        onReceived = _props.onReceived,
-        onInitialized = _props.onInitialized,
-        onConnected = _props.onConnected,
-        onDisconnected = _props.onDisconnected,
-        onRejected = _props.onRejected;
+    this.subscribe(this.props)
+  },
+
+  subscribe: function(props) {
+    var onReceived = props.onReceived,
+        onInitialized = props.onInitialized,
+        onConnected = props.onConnected,
+        onDisconnected = props.onDisconnected,
+        onRejected = props.onRejected;
 
     this.cable = this.context.cable.subscriptions.create(
-      this.props.channel,
+      props.channel,
       {
         received: function (data) {
           onReceived && onReceived(data)
@@ -93,11 +96,25 @@ var ActionCable = createReactClass({
     )
   },
 
-  componentWillUnmount: function () {
+  unsubscribe: function() {
     if (this.cable) {
       this.context.cable.subscriptions.remove(this.cable)
       this.cable = null
     }
+  },
+
+  componentWillUnmount: function () {
+    this.unsubscribe()
+  },
+
+  componentWillReceiveProps: function (nextProps) {
+    // recreate the subscription when channel changes
+    if (_isEqual(this.props.channel, nextProps.channel)) {
+      return
+    }
+
+    this.unsubscribe()
+    this.subscribe(nextProps)
   },
 
   send: function (data) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "actioncable": "^5.0.0",
     "create-react-class": "^15.6.2",
+    "lodash": "^4.17.5",
     "prop-types": "^15.6.0",
     "react": "^16.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,6 +2231,10 @@ lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.5:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"


### PR DESCRIPTION
This fixes an issue where if your component had a channel based on the props the subscription wasn’t refreshing when the channel was changing.