### PR TITLE
Fix ActionCableConsumer component unmounting/remounting on parent component rerender

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,34 +136,34 @@ ActionCableController.propTypes = {
   children: PropTypes.any
 }
 
-var ActionCableConsumer = React.forwardRef(function (props, ref) {
-  var Component = createReactClass({
-    render: function () {
-      return React.createElement(Consumer, null, ({ cable }) => {
-        return React.createElement(
-          ActionCableController,
-          {
-            cable,
-            ...this.props,
-            ref: this.props.forwardedRef
-          },
-          this.props.children || null
-        )
-      })
-    }
-  })
-
-  Component.displayName = "ActionCableConsumer"
-
-  Component.propTypes = {
-    onReceived: PropTypes.func,
-    onInitialized: PropTypes.func,
-    onConnected: PropTypes.func,
-    onDisconnected: PropTypes.func,
-    onRejected: PropTypes.func,
-    children: PropTypes.any
+var Component = createReactClass({
+  render: function () {
+    return React.createElement(Consumer, null, ({ cable }) => {
+      return React.createElement(
+        ActionCableController,
+        {
+          cable,
+          ...this.props,
+          ref: this.props.forwardedRef
+        },
+        this.props.children || null
+      )
+    })
   }
+})
 
+Component.displayName = "ActionCableConsumer"
+
+Component.propTypes = {
+  onReceived: PropTypes.func,
+  onInitialized: PropTypes.func,
+  onConnected: PropTypes.func,
+  onDisconnected: PropTypes.func,
+  onRejected: PropTypes.func,
+  children: PropTypes.any
+}
+
+var ActionCableConsumer = React.forwardRef(function (props, ref) {
   return React.createElement(
     Component,
     {


### PR DESCRIPTION
This fixes the issue of the ActionCableConsumer component being unmounted and remounted every 
time the parent component rerenders. 

Since a new ActionCableConsumer class component was being created every time the forwardRef function runs, it was continually unmounting and mounting new versions of the component. This would also have the effect of unsubscribing and re-subscribing to the socket connection each time the parent rerenders, not just when the parent component unmounts.

I moved the createReactClass function outside of the forwardRef function and the component now behaves as expected.

Fixes #21 