### PR TITLE
Run lifecycle code mod renaming unsafe

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ var createReactClass = require("create-react-class")
 var { Provider, Consumer } = React.createContext()
 
 var ActionCableProvider = createReactClass({
-  componentWillMount: function () {
+  UNSAFE_componentWillMount: function () {
     if (this.props.cable) {
       this.cable = this.props.cable
     } else {
@@ -25,7 +25,7 @@ var ActionCableProvider = createReactClass({
     }
   },
 
-  componentWillReceiveProps: function (nextProps) {
+  UNSAFE_componentWillReceiveProps: function (nextProps) {
     // Props not changed
     if (
       this.props.cable === nextProps.cable &&
@@ -38,7 +38,7 @@ var ActionCableProvider = createReactClass({
     this.componentWillUnmount()
 
     // create or assign cable
-    this.componentWillMount()
+    this.UNSAFE_componentWillMount()
   },
 
   render: function () {


### PR DESCRIPTION
In response to #28 and for my own app, I wanted this to remove the warnings for react lifecycle deprecations. I ran `npx react-codemod rename-unsafe-lifecycles` based on react guidance. Nothing special but it'd be helpful for now https://reactjs.org/blog/2019/08/08/react-v16.9.0.html